### PR TITLE
Remove variable that was not used, to remove hint

### DIFF
--- a/XSuperObject.pas
+++ b/XSuperObject.pas
@@ -1295,7 +1295,7 @@ end;
 class function TSuperObject.ParseStream(Stream: TStream; CheckDate: Boolean): TSuperObject;
 var
   Strm: TStringStream;
-  preamble, tmp: TBytes;
+  tmp: TBytes;
   preambleLength: integer;
   enc: TEncoding;
 begin


### PR DESCRIPTION
This pull request removes an unused variable, thus removing a hint generated by Delphi