### PR TITLE
resolved issue #141 about AccessViolations whith multithreading by ap…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ iOSSimulator/
 
 # Castalia statistics file (since XE7 Castalia is distributed with Delphi)
 *.stat
+*.bak


### PR DESCRIPTION
…plying corrections suggested by @CaptainNemo07.

changes are:
1) uses one static RTTIContext instead of continuing creating and destroying local RTTI Context
2) uses a CriticalSection to protect all Superobject methods, since RTTI is clearly not ok with multithreading.
3) point 1 indirectly fixes some bugs in the original code: in some places the local RTTIContext freed in a Except sction instead of a finally section.

_I declared both the critical section and the RTTIContext as a private class variables contained in TBase (they have to be declared in the "interface" section of the unit to be used inside the code of generic classes: they can't be declared as plain global variables inside the implementation section of the unit because of how the delphi compiler implements generic classes when they get instantiated)_

See the issue to find two test programs (one posted by me) that will cause for sure those concurrency problems. Let me point out that without this fix XSuperobject is totally unusable in a windows based rest server subject to multiple concurrent requests from hundreds of clients (which was my case)

 (honest question: is this project still being maintained? A project like this seriously needs unit test cases with 99% code coverage...)
